### PR TITLE
Feature/inject saved replies into dialog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,98 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents when working with code in this repository.
+
+## Project Overview
+
+Shared Saved Replies is a dual-platform browser extension (Chrome + Firefox) that populates GitHub's saved replies UI with templates fetched from markdown files in GitHub repositories. Templates are parsed from H2 headers followed by markdown code blocks in `.md` files.
+
+## Build and Test
+
+### Build (.NET solution, used for tests only)
+
+```bash
+dotnet build src --configuration Release
+```
+
+### Run Tests (Playwright + NUnit, currently disabled/ignored)
+
+```bash
+# Install Playwright browsers first
+pwsh ./install.ps1
+
+# Run tests
+dotnet test src --configuration Release
+```
+
+Tests use Playwright to launch Chromium with the Chrome extension loaded. The test web host serves fake GitHub pages (`fake-issue.html`, `fake-response.json`) for integration testing.
+
+### Package Extensions
+
+```bash
+pwsh ./package.ps1
+```
+
+This PowerShell script derives the version from MinVer (`minver -v warn`), updates both `manifest.json` files, and creates ZIP archives for distribution.
+
+## Architecture
+
+### Dual-Platform Extensions
+
+The Chrome and Firefox extensions live in parallel directory structures under `src/`:
+
+- **`src/ChromeExtension/`** - Manifest V3, uses `chrome.*` APIs, service worker background, `sidePanel` API, offscreen documents
+- **`src/FirefoxExtension/`** - Manifest V3 with gecko settings, uses `browser.*` APIs, `sidebar_action` API, ES module background scripts
+
+Both extensions share the same conceptual architecture but are **not code-shared at build time**; each has its own copy of files. Firefox has additional modules (e.g., `github-permissions.js`, `sidepanel-elements.js`) because it handles sidebar and permissions differently.
+
+### Extension Component Structure (both platforms)
+
+| Directory | Purpose |
+|-----------|---------|
+| `pages/content-script/` | Injected into GitHub pages; adds saved reply buttons to comment areas |
+| `pages/service-worker/` | Background processing: alarms, storage, messaging, settings |
+| `pages/popup/` | Extension popup UI for managing saved reply configurations |
+| `pages/sidepanel/` (Chrome) / `pages/sidepanel/` (Firefox) | Side panel UI showing saved replies |
+| `pages/options/` | Extension options page |
+| `pages/shared-saved-replies-form/` | Form for adding/editing saved reply sources |
+| `js/modules/` | Shared utility modules (messaging, DOM creation, theming, etc.) |
+| `css/` | Stylesheets including Prism.js syntax highlighting and theme support |
+
+### Key Platform Differences
+
+- Chrome uses `chrome.sidePanel`; Firefox uses `browser.sideAction` (sidebar)
+- Chrome service worker is a single file; Firefox uses `"type": "module"` with script array
+- Firefox requires explicit `browser_specific_settings.gecko` in manifest
+- Chrome has `offscreen` document support; Firefox does not
+- Content script injection: Chrome uses messaging; Firefox listens for `"soft-nav:end"` events
+
+### Messaging System
+
+Cross-component communication uses a message protocol with `messageType` (command/event), `target`, and `messageName` fields. Messages route between content scripts, service workers, popups, and side panels.
+
+### Test Infrastructure
+
+- `src/Tests/Tests/` - NUnit test project using Playwright for browser automation
+- `src/Tests/WebHost/` - ASP.NET web app serving fake GitHub pages for testing
+- `ChromeExtensionPageTest.cs` - Base class that launches Chromium with the extension loaded
+- `ChromeExtensionTestServerPageTest.cs` - Manages test web server lifecycle
+
+## Versioning
+
+- Uses **MinVer** to derive semantic versions from git tags
+- Tags follow pattern: `MAJOR.MINOR.PATCH` (e.g., `0.0.6`)
+- Chrome and Firefox versions may differ (Chrome is currently ahead)
+- `package.ps1` auto-updates manifest versions during packaging
+
+## Release Process
+
+- Chrome: Tag triggers GitHub Actions workflow that packages, signs, and uploads to Chrome Web Store
+- Firefox: Manual upload to [Firefox Add-ons](https://addons.mozilla.org/en-US/developers/addon/shared-saved-replies/versions/submit/)
+- See `docs/deploy.md` for deployment instructions
+
+## Code Conventions
+
+- Pure JavaScript (no TypeScript, no bundler, no transpilation)
+- No package manager or `node_modules`; all JS dependencies are vendored (e.g., `prism.js`)
+- .NET test projects use nullable reference types and implicit usings
+- When modifying extension behavior, changes typically need to be applied to **both** Chrome and Firefox extensions separately

--- a/src/ChromeExtension/js/modules/settings.js
+++ b/src/ChromeExtension/js/modules/settings.js
@@ -17,7 +17,8 @@ const getSettings = async () => {
         limitToGitHubOwner: settings.limitToGitHubOwnerDefault,
         includeIssues: settings.includeIssuesDefault,
         includePullRequests: settings.includePullRequestsDefault,
-        refreshRateInMinutes: settings.refreshRateInMinutesDefault
+        refreshRateInMinutes: settings.refreshRateInMinutesDefault,
+        showSidebarButton: settings.showSidebarButtonDefault ?? true
     }
 }
 

--- a/src/ChromeExtension/js/urls.js
+++ b/src/ChromeExtension/js/urls.js
@@ -25,7 +25,7 @@ const isGitHubIssueUrl = (url) => {
         url = window.location.href;
      }
  
-     const issueUrlPattern = /^(https?:\/\/)github\.com\/.+\/.+\/issues\/\d+/i;
+     const issueUrlPattern = /^(https?:\/\/)github\.com\/.+\/.+\/issues\/(\d+|new)/i;
  
      const projectIssueUrlPattern = /^https:\/\/github.com\/(orgs|users)\/(?<owner>\w+)\/projects\/\d+(?:.*)(?:[?|&]pane=\S+&*)(?:issue=\S+)/i;
  
@@ -60,7 +60,7 @@ const getGitHubOwner = (url) => {
         url = window.location.href;
     }
 
-    const issueOrPrOwnerPattern = /https:\/\/github.com\/(?<owner>[\w]+)\/\w+\/(pull|issues)\/.+/i
+    const issueOrPrOwnerPattern = /https:\/\/github.com\/(?<owner>[\w.-]+)\/[\w.-]+\/(pull|issues)\/.+/i
 
     if(issueOrPrOwnerPattern.test(url)){
        

--- a/src/ChromeExtension/manifest.json
+++ b/src/ChromeExtension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Shared Saved Replies",
   "description": "Adds saved replies to GitHub's saved replies list when commenting on issues or pull requests.",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "action":{
     "default_popup": "pages/popup/popup.html"
   },

--- a/src/ChromeExtension/pages/content-script/content-script-copy-saved-reply-element.js
+++ b/src/ChromeExtension/pages/content-script/content-script-copy-saved-reply-element.js
@@ -1,186 +1,320 @@
-const getsSavedRepliesForNestedIssuesContainer = () =>
-     document.querySelector(`#__primerPortalRoot__  div[role="listbox"] > div`);
+const SHARED_REPLY_ATTR = "data-shared-saved-reply";
+const SHARED_LISTBOX_ATTR = "data-shared-saved-reply-listbox";
+let _cachedSavedReplies = null;
+let _cachedTemplateItem = null;
+let _cachedListboxClone = null;
+let _dialogObserverActive = false;
 
-const getLastExistingSavedReplyElement = (savedRepliesContainer) => {
-    
-    let savedReplyElements = 
-        savedRepliesContainer.querySelectorAll(`div[tabindex="-1"][role="option"]`);
+const isSavedRepliesDialog = (element) => {
+    if (!element || !element.querySelector) return false;
+    return element.querySelector('input[placeholder="Search saved replies"]') !== null;
+};
 
-     let lastSavedReplyElement = savedReplyElements[savedReplyElements.length- 1]
+const matchesSearch = (reply, searchText) => {
+    if (!searchText) return true;
+    return reply.name.toLowerCase().includes(searchText);
+};
 
-     return lastSavedReplyElement;
-}
-   
-const calculateSavedReplyId = (lastId, savedReplyIndex) => {
-   
-   let numberIndex = lastId.search(`[0-9]`);
-   
-   if(numberIndex !== -1){
-      
-      let lastIdNumber = Number(lastId.substring(numberIndex)); 
-      
-      let newNumericalId = lastIdNumber + savedReplyIndex + 1;
+const insertReplyIntoTextarea = (body) => {
+    const textarea = document.querySelector(
+        'textarea[name="comment[body]"], div[data-testid="markdown-editor-comment-composer"] textarea, textarea[class*="prc-Textarea-TextArea"]'
+    );
+    if (!textarea) return;
 
-      let idPrefix = lastId.substring(0, numberIndex);
-      
-      let newId = idPrefix + new String(newNumericalId);
-      
-      return newId;
-   }
-   else{
-        
-        return lastId;
-   }
-}
+    textarea.focus();
 
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const currentValue = textarea.value;
+    const newValue = currentValue.substring(0, start) + body + currentValue.substring(end);
 
+    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+        window.HTMLTextAreaElement.prototype, 'value'
+    ).set;
 
-const setElementSavedReplyName = (element, name) =>{
+    nativeInputValueSetter.call(textarea, newValue);
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
 
-    element.setAttribute(`saved-reply-name`, name);
-}
+    // Place cursor at the end of the inserted text
+    const newCursorPos = start + body.length;
+    textarea.setSelectionRange(newCursorPos, newCursorPos);
+};
 
+const closeSavedRepliesDialog = () => {
+    const target = document.activeElement || document.body;
+    target.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Escape',
+        code: 'Escape',
+        keyCode: 27,
+        which: 27,
+        bubbles: true,
+        cancelable: true
+    }));
+};
 
-const setSavedReplyId = (element,calculatedId) => {
- 
-    element.id = calculatedId;
-}
+const ACTIVE_ATTR = "data-shared-active";
 
-const setSavedReplyName = (nameSpan, name) => {
-     
-    nameSpan.innerText = name;
-}
+const createReplyListItem = (templateItem, reply, index) => {
+    const item = templateItem.cloneNode(true);
 
+    item.setAttribute(SHARED_REPLY_ATTR, "true");
 
-const encodeSavedReplyBody = (body) => {
-   
-   let updatedBody = 
-        body.replace(/\r\n/gi, '\\uFFFD')
-            .replace(/\n/gi,'\\uFFFD');
+    const baseId = `shared-reply-${index}`;
+    item.id = baseId;
+    item.setAttribute("data-id", `shared-${index}`);
+    item.removeAttribute("data-first-child");
+    item.removeAttribute("aria-current");
+    item.removeAttribute("data-is-active-descendant");
+    item.setAttribute("aria-selected", "false");
+    item.setAttribute("aria-labelledby", `${baseId}--label`);
+    item.setAttribute("aria-describedby", `${baseId}--block-description`);
 
-   return updatedBody;
-}
-
-const setSavedReplyBody = (bodySpan, body) => {
-
-    let encodedBody = encodeSavedReplyBody(body);
-
-    bodySpan.innerText = encodedBody;
-}
-
-const createNewSavedReplyElementFromExistingElment = (templateElement, savedReply, index) => {
-
-    let spans = templateElement.querySelectorAll(`span`);
-    console.log("bodyspan", spans[1]);
-    console.log("bodyspanInnerText", spans[1].innerText);
-    console.log("savereplybody", savedReply.body);
-
-    let newSavedReplyElement = templateElement.cloneNode(true);
-    
-    let savedReplySpans = newSavedReplyElement.querySelectorAll(`span`);
-
-    let nameSpan = savedReplySpans[0];
-
-    let bodySpan = savedReplySpans[1];
-
-    setElementSavedReplyName(newSavedReplyElement, savedReply.name);
-
-    setSavedReplyName(nameSpan, savedReply.name);
-
-    setSavedReplyBody(bodySpan, savedReply.body);
-
-    let id = calculateSavedReplyId(templateElement.id, index);
-
-    setSavedReplyId(newSavedReplyElement, id);
-
-    return newSavedReplyElement;
-}
-
-const createSavedRepliesUIForNestedIssues = (savedReplies) => {
-
-    let savedRepliesDivs = [];
-
-    let savedRepliesContainer = getsSavedRepliesForNestedIssuesContainer();
-
-    let lastSavedReplyElement = getLastExistingSavedReplyElement(savedRepliesContainer);
-  
-    for (const [index, reply] of savedReplies.entries()){
-
-        let newElement = 
-            createNewSavedReplyElementFromExistingElment(lastSavedReplyElement, reply, index);
-
-        savedRepliesDivs.push(newElement);
+    // Hide the checkmark SVG but keep the selection span for indentation and blue bar
+    const checkmark = item.querySelector('[data-component="ActionList.Selection"] svg');
+    if (checkmark) {
+        checkmark.style.visibility = "hidden";
     }
 
-    return savedRepliesDivs;
-}
 
-const addNewSavedReplyElementToContainer = (savedRepliesContainer,savedReplyElement ) => {
-    
-    savedRepliesContainer.appendChild(savedReplyElement);
-}
+    const labelSpan = item.querySelector('[id$="--label"]');
+    if (labelSpan) {
+        labelSpan.id = `${baseId}--label`;
+        labelSpan.textContent = reply.name;
+    }
 
-const getElementSavedReplyName = (element) =>{
+    const descSpan = item.querySelector('[data-component="ActionList.Description"]');
+    if (descSpan) {
+        descSpan.id = `${baseId}--block-description`;
+        descSpan.textContent = reply.body;
+    }
 
-    return element.getAttribute(`saved-reply-name`);
-}
+    const trailingVisual = item.querySelector('[id$="--trailing-visual"]');
+    if (trailingVisual) {
+        trailingVisual.id = `${baseId}--trailing-visual`;
+        trailingVisual.textContent = "";
+    }
 
-const getSavedReplyTitleSpan = (savedReplyDiv) => {
-
-}
-
-const getSavedReplyTemplateString = (savedReplyDiv) =>{
-    
-    let bodySpan = savedReplyDiv.querySelectorAll(`span`)[1]
-    
-    let decodedTemplate = bodySpan.innerText
-        .replace(/(\\uFFFD)+/gi,'<br />');
-
-    return decodedTemplate;
-}
-
-const addEventListenerToSavedReplyDiv = (savedReplyDiv, textAreaElement) =>{
-    
-    let templateString = getSavedReplyTemplateString(savedReplyDiv, textAreaElement);
-       
-    savedReplyDiv.addEventListener(`click`, function(e){
-
-        textAreaElement.innerHtml = templateString;
-
-        console.log("text area value", textAreaElement.value);
-
+    item.addEventListener("mouseenter", () => {
+        const listbox = item.closest('ul[role="listbox"]');
+        // Clear active state from all siblings
+        listbox?.querySelectorAll("[data-is-active-descendant]").forEach(el => {
+            el.removeAttribute("data-is-active-descendant");
+            el.removeAttribute(ACTIVE_ATTR);
+            el.style.backgroundColor = "";
+        });
+        item.setAttribute("data-is-active-descendant", "true");
+        item.setAttribute(ACTIVE_ATTR, "true");
+        if (listbox) listbox.setAttribute("data-has-active-descendant", item.id);
+    });
+    item.addEventListener("mouseleave", () => {
+        item.removeAttribute("data-is-active-descendant");
+        item.removeAttribute(ACTIVE_ATTR);
+        const listbox = item.closest('ul[role="listbox"]');
+        if (listbox) listbox.removeAttribute("data-has-active-descendant");
     });
 
-}
+    item.addEventListener("click", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        insertReplyIntoTextarea(reply.body);
+        closeSavedRepliesDialog();
+    });
 
-const getCommentTextAreaElement = () => {
+    return item;
+};
 
-    let textAreaElement =
-    document.querySelector(
-        `div[data-testid="markdown-editor-comment-composer"] textarea`);
+const injectSharedReplies = (listbox, savedReplies, searchText) => {
+    listbox.querySelectorAll(`[${SHARED_REPLY_ATTR}]`).forEach(el => el.remove());
 
-    return textAreaElement;
-}
+    const nativeItem = listbox.querySelector(`li[role="option"]:not([${SHARED_REPLY_ATTR}])`);
+    if (nativeItem) {
+        _cachedTemplateItem = nativeItem.cloneNode(true);
+    }
 
-const addNewSavedRepliesToNestedIssuesContainer = (savedRepliesDivs, savedRepliesContainer) =>{
-   
-    let textAreaElement = getCommentTextAreaElement();
+    if (!_cachedTemplateItem) return;
 
-    for (const savedReplyDiv of savedRepliesDivs){
+    const filteredReplies = savedReplies.filter(r => matchesSearch(r, searchText));
 
-        let savedReplyName = savedReplyDiv.getAttribute(`saved-reply-name`);
+    console.log("injectSharedReplies: searchText =", searchText, "filtered =", filteredReplies.length, "of", savedReplies.length);
 
-        let matchingDiv = savedRepliesContainer.querySelector(`div[saved-reply-name="${savedReplyName}"]`);
+    for (const [index, reply] of filteredReplies.entries()) {
+        const item = createReplyListItem(_cachedTemplateItem, reply, index);
+        listbox.appendChild(item);
+    }
+};
 
-        if(!matchingDiv){
+const getOrCreateListbox = (dialog) => {
+    // First, remove any listbox we previously created
+    const previouslyCreated = dialog.querySelector(`[${SHARED_LISTBOX_ATTR}]`);
 
-            addEventListenerToSavedReplyDiv(savedReplyDiv, textAreaElement);
-
-            savedRepliesContainer.appendChild(savedReplyDiv);
+    // Check if React's listbox exists
+    const existingListbox = dialog.querySelector(`ul[role="listbox"]:not([${SHARED_LISTBOX_ATTR}])`);
+    if (existingListbox) {
+        // React's listbox is present; remove ours if we created one
+        if (previouslyCreated) {
+            previouslyCreated.remove();
         }
-     }
-}
+        return existingListbox;
+    }
 
-const removeNewSavedRepliesToNestedIssuesContainer = () =>{
-    
-}
+    // React removed its listbox (no native matches). Create one from cache.
+    if (!_cachedListboxClone) return null;
+
+    const container = dialog.querySelector('[data-testid="filtered-action-list"] > div:last-child')
+        || dialog.querySelector('[data-testid="filtered-action-list"]');
+    if (!container) return null;
+
+    if (previouslyCreated) {
+        return previouslyCreated;
+    }
+
+    const listbox = _cachedListboxClone.cloneNode(false);
+    listbox.setAttribute(SHARED_LISTBOX_ATTR, "true");
+    container.prepend(listbox);
+
+    console.log("getOrCreateListbox: created fallback listbox in container");
+
+    return listbox;
+};
+
+const hideNoItemsMessage = (dialog, hide) => {
+    const message = dialog.querySelector('[class*="SelectPanel-Message"]');
+    if (message) {
+        message.style.display = hide ? "none" : "";
+    }
+};
+
+const injectIntoCurrentListbox = (dialog, searchText) => {
+    const listbox = getOrCreateListbox(dialog);
+    if (!listbox) return;
+
+    injectSharedReplies(listbox, _cachedSavedReplies, searchText);
+
+    const hasSharedItems = listbox.querySelector(`[${SHARED_REPLY_ATTR}]`) !== null;
+    hideNoItemsMessage(dialog, hasSharedItems);
+};
+
+const onSavedRepliesDialogOpened = async (dialog) => {
+    console.log("onSavedRepliesDialogOpened: dialog detected");
+
+    if (!_cachedSavedReplies) {
+        _cachedSavedReplies = await getMatchingSavedReplyConfigsFromLocalStorage(null);
+        console.log("onSavedRepliesDialogOpened: loaded replies from storage", _cachedSavedReplies);
+    }
+
+    if (!_cachedSavedReplies || _cachedSavedReplies.length === 0) {
+        console.log("onSavedRepliesDialogOpened: no saved replies found in storage");
+        return;
+    }
+
+    const initialInject = () => {
+        const listbox = dialog.querySelector('ul[role="listbox"]');
+        if (!listbox) return false;
+
+        // Cache the listbox element (empty clone) for when React removes it
+        _cachedListboxClone = listbox.cloneNode(false);
+        _cachedListboxClone.removeAttribute("data-has-active-descendant");
+
+        injectSharedReplies(listbox, _cachedSavedReplies, "");
+
+        // Use event delegation on dialog so handlers survive React replacing elements
+        dialog.addEventListener("input", (e) => {
+            if (!e.target.matches('input[placeholder="Search saved replies"]')) return;
+            const searchText = e.target.value.toLowerCase();
+            console.log("search input changed:", searchText);
+            setTimeout(() => injectIntoCurrentListbox(dialog, searchText), 0);
+        });
+
+        dialog.addEventListener("keydown", (e) => {
+            if (e.key !== "ArrowDown" && e.key !== "ArrowUp" && e.key !== "Enter") return;
+
+            const currentListbox = getOrCreateListbox(dialog);
+            if (!currentListbox) return;
+
+            // Only handle navigation when no native items exist
+            const hasNativeItems = currentListbox.querySelector(`li[role="option"]:not([${SHARED_REPLY_ATTR}])`);
+            if (hasNativeItems) return;
+
+            const items = Array.from(currentListbox.querySelectorAll(`[${SHARED_REPLY_ATTR}]`));
+            if (items.length === 0) return;
+
+            e.preventDefault();
+            e.stopPropagation();
+
+            const selectedIndex = items.findIndex(item => item.hasAttribute(ACTIVE_ATTR));
+
+            if (e.key === "Enter") {
+                if (selectedIndex >= 0) {
+                    items[selectedIndex].click();
+                }
+                return;
+            }
+
+            let nextIndex;
+            if (e.key === "ArrowDown") {
+                nextIndex = selectedIndex < items.length - 1 ? selectedIndex + 1 : 0;
+            } else {
+                nextIndex = selectedIndex > 0 ? selectedIndex - 1 : items.length - 1;
+            }
+
+            items.forEach(item => {
+                item.removeAttribute(ACTIVE_ATTR);
+                item.removeAttribute("data-is-active-descendant");
+                item.style.backgroundColor = "";
+            });
+            items[nextIndex].setAttribute(ACTIVE_ATTR, "true");
+            items[nextIndex].setAttribute("data-is-active-descendant", "true");
+            items[nextIndex].style.backgroundColor = "var(--control-transparent-bgColor-hover, rgba(175,184,193,0.12))";
+            currentListbox.setAttribute("data-has-active-descendant", items[nextIndex].id);
+            items[nextIndex].scrollIntoView({ block: "nearest" });
+        });
+
+        return true;
+    };
+
+    if (initialInject()) return;
+
+    console.log("onSavedRepliesDialogOpened: listbox not yet rendered, waiting...");
+
+    const dialogObserver = new MutationObserver(() => {
+        if (initialInject()) {
+            console.log("onSavedRepliesDialogOpened: listbox appeared");
+            dialogObserver.disconnect();
+        }
+    });
+    dialogObserver.observe(dialog, { childList: true, subtree: true });
+};
+
+const observeSavedRepliesDialog = () => {
+    if (_dialogObserverActive) return;
+    _dialogObserverActive = true;
+
+    console.log("observeSavedRepliesDialog: observer active");
+
+    const observer = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+            for (const node of mutation.addedNodes) {
+                if (node.nodeType !== Node.ELEMENT_NODE) continue;
+
+                let dialog = null;
+                if (node.getAttribute && node.getAttribute('role') === 'dialog') {
+                    dialog = node;
+                } else if (node.querySelector) {
+                    dialog = node.querySelector('[role="dialog"]');
+                }
+
+                if (dialog && isSavedRepliesDialog(dialog)) {
+                    onSavedRepliesDialogOpened(dialog);
+                }
+            }
+        }
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
+};
+
+document.addEventListener("soft-nav:end", () => {
+    _cachedSavedReplies = null;
+    _cachedTemplateItem = null;
+    _cachedListboxClone = null;
+});

--- a/src/ChromeExtension/pages/content-script/content-script-copy-saved-reply-element.js
+++ b/src/ChromeExtension/pages/content-script/content-script-copy-saved-reply-element.js
@@ -1,14 +1,31 @@
 const SHARED_REPLY_ATTR = "data-shared-saved-reply";
 const SHARED_LISTBOX_ATTR = "data-shared-saved-reply-listbox";
+const ACTIVE_ATTR = "data-shared-active";
 let _cachedSavedReplies = null;
 let _cachedTemplateItem = null;
 let _cachedListboxClone = null;
+let _cachedLegacyTemplateItem = null;
 let _dialogObserverActive = false;
 
-const isSavedRepliesDialog = (element) => {
+// --- Detection ---
+
+const isPrimerReactDialog = (element) => {
     if (!element || !element.querySelector) return false;
     return element.querySelector('input[placeholder="Search saved replies"]') !== null;
 };
+
+const isLegacyDialog = (element) => {
+    if (!element) return false;
+    if (element.classList?.contains('js-saved-reply-container')) return true;
+    if (element.querySelector?.('.js-saved-reply-container')) return true;
+    return false;
+};
+
+const isSavedRepliesDialog = (element) => {
+    return isPrimerReactDialog(element) || isLegacyDialog(element);
+};
+
+// --- Shared helpers ---
 
 const matchesSearch = (reply, searchText) => {
     if (!searchText) return true;
@@ -17,7 +34,7 @@ const matchesSearch = (reply, searchText) => {
 
 const insertReplyIntoTextarea = (body) => {
     const textarea = document.querySelector(
-        'textarea[name="comment[body]"], div[data-testid="markdown-editor-comment-composer"] textarea, textarea[class*="prc-Textarea-TextArea"]'
+        '#new_comment_field, textarea[name="comment[body]"], div[data-testid="markdown-editor-comment-composer"] textarea, textarea[class*="prc-Textarea-TextArea"]'
     );
     if (!textarea) return;
 
@@ -35,7 +52,6 @@ const insertReplyIntoTextarea = (body) => {
     nativeInputValueSetter.call(textarea, newValue);
     textarea.dispatchEvent(new Event('input', { bubbles: true }));
 
-    // Place cursor at the end of the inserted text
     const newCursorPos = start + body.length;
     textarea.setSelectionRange(newCursorPos, newCursorPos);
 };
@@ -52,7 +68,7 @@ const closeSavedRepliesDialog = () => {
     }));
 };
 
-const ACTIVE_ATTR = "data-shared-active";
+// --- Primer React dialog (issues, new issues) ---
 
 const createReplyListItem = (templateItem, reply, index) => {
     const item = templateItem.cloneNode(true);
@@ -69,12 +85,10 @@ const createReplyListItem = (templateItem, reply, index) => {
     item.setAttribute("aria-labelledby", `${baseId}--label`);
     item.setAttribute("aria-describedby", `${baseId}--block-description`);
 
-    // Hide the checkmark SVG but keep the selection span for indentation and blue bar
     const checkmark = item.querySelector('[data-component="ActionList.Selection"] svg');
     if (checkmark) {
         checkmark.style.visibility = "hidden";
     }
-
 
     const labelSpan = item.querySelector('[id$="--label"]');
     if (labelSpan) {
@@ -96,7 +110,6 @@ const createReplyListItem = (templateItem, reply, index) => {
 
     item.addEventListener("mouseenter", () => {
         const listbox = item.closest('ul[role="listbox"]');
-        // Clear active state from all siblings
         listbox?.querySelectorAll("[data-is-active-descendant]").forEach(el => {
             el.removeAttribute("data-is-active-descendant");
             el.removeAttribute(ACTIVE_ATTR);
@@ -135,8 +148,6 @@ const injectSharedReplies = (listbox, savedReplies, searchText) => {
 
     const filteredReplies = savedReplies.filter(r => matchesSearch(r, searchText));
 
-    console.log("injectSharedReplies: searchText =", searchText, "filtered =", filteredReplies.length, "of", savedReplies.length);
-
     for (const [index, reply] of filteredReplies.entries()) {
         const item = createReplyListItem(_cachedTemplateItem, reply, index);
         listbox.appendChild(item);
@@ -144,20 +155,16 @@ const injectSharedReplies = (listbox, savedReplies, searchText) => {
 };
 
 const getOrCreateListbox = (dialog) => {
-    // First, remove any listbox we previously created
     const previouslyCreated = dialog.querySelector(`[${SHARED_LISTBOX_ATTR}]`);
 
-    // Check if React's listbox exists
     const existingListbox = dialog.querySelector(`ul[role="listbox"]:not([${SHARED_LISTBOX_ATTR}])`);
     if (existingListbox) {
-        // React's listbox is present; remove ours if we created one
         if (previouslyCreated) {
             previouslyCreated.remove();
         }
         return existingListbox;
     }
 
-    // React removed its listbox (no native matches). Create one from cache.
     if (!_cachedListboxClone) return null;
 
     const container = dialog.querySelector('[data-testid="filtered-action-list"] > div:last-child')
@@ -171,8 +178,6 @@ const getOrCreateListbox = (dialog) => {
     const listbox = _cachedListboxClone.cloneNode(false);
     listbox.setAttribute(SHARED_LISTBOX_ATTR, "true");
     container.prepend(listbox);
-
-    console.log("getOrCreateListbox: created fallback listbox in container");
 
     return listbox;
 };
@@ -194,34 +199,27 @@ const injectIntoCurrentListbox = (dialog, searchText) => {
     hideNoItemsMessage(dialog, hasSharedItems);
 };
 
-const onSavedRepliesDialogOpened = async (dialog) => {
-    console.log("onSavedRepliesDialogOpened: dialog detected");
+const onPrimerReactDialogOpened = async (dialog) => {
+    console.log("onPrimerReactDialogOpened: dialog detected");
 
     if (!_cachedSavedReplies) {
         _cachedSavedReplies = await getMatchingSavedReplyConfigsFromLocalStorage(null);
-        console.log("onSavedRepliesDialogOpened: loaded replies from storage", _cachedSavedReplies);
     }
 
-    if (!_cachedSavedReplies || _cachedSavedReplies.length === 0) {
-        console.log("onSavedRepliesDialogOpened: no saved replies found in storage");
-        return;
-    }
+    if (!_cachedSavedReplies || _cachedSavedReplies.length === 0) return;
 
     const initialInject = () => {
         const listbox = dialog.querySelector('ul[role="listbox"]');
         if (!listbox) return false;
 
-        // Cache the listbox element (empty clone) for when React removes it
         _cachedListboxClone = listbox.cloneNode(false);
         _cachedListboxClone.removeAttribute("data-has-active-descendant");
 
         injectSharedReplies(listbox, _cachedSavedReplies, "");
 
-        // Use event delegation on dialog so handlers survive React replacing elements
         dialog.addEventListener("input", (e) => {
             if (!e.target.matches('input[placeholder="Search saved replies"]')) return;
             const searchText = e.target.value.toLowerCase();
-            console.log("search input changed:", searchText);
             setTimeout(() => injectIntoCurrentListbox(dialog, searchText), 0);
         });
 
@@ -231,7 +229,6 @@ const onSavedRepliesDialogOpened = async (dialog) => {
             const currentListbox = getOrCreateListbox(dialog);
             if (!currentListbox) return;
 
-            // Only handle navigation when no native items exist
             const hasNativeItems = currentListbox.querySelector(`li[role="option"]:not([${SHARED_REPLY_ATTR}])`);
             if (hasNativeItems) return;
 
@@ -274,15 +271,128 @@ const onSavedRepliesDialogOpened = async (dialog) => {
 
     if (initialInject()) return;
 
-    console.log("onSavedRepliesDialogOpened: listbox not yet rendered, waiting...");
-
     const dialogObserver = new MutationObserver(() => {
         if (initialInject()) {
-            console.log("onSavedRepliesDialogOpened: listbox appeared");
             dialogObserver.disconnect();
         }
     });
     dialogObserver.observe(dialog, { childList: true, subtree: true });
+};
+
+// --- Legacy dialog (PRs) ---
+
+const createLegacyReplyListItem = (templateItem, reply, index) => {
+    const item = templateItem.cloneNode(true);
+
+    item.setAttribute(SHARED_REPLY_ATTR, "true");
+    item.setAttribute("data-value", reply.name);
+
+    const labelSpan = item.querySelector('.ActionListItem-label');
+    if (labelSpan) {
+        labelSpan.textContent = reply.name;
+    }
+
+    const bodySpan = item.querySelector('.js-saved-reply-body .Truncate-text');
+    if (bodySpan) {
+        bodySpan.textContent = reply.body;
+    }
+
+    const trailingLabel = item.querySelector('.ActionListItem-visual--trailing .Label');
+    if (trailingLabel) {
+        trailingLabel.textContent = "";
+    }
+
+    const button = item.querySelector('button');
+    if (button) {
+        button.addEventListener("click", (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            insertReplyIntoTextarea(reply.body);
+
+            const dialogEl = item.closest('dialog');
+            if (dialogEl) dialogEl.close();
+        });
+    }
+
+    return item;
+};
+
+const injectIntoLegacyList = (list) => {
+    if (list.querySelector(`[${SHARED_REPLY_ATTR}]`)) return;
+
+    const templateItem = list.querySelector('li.ActionListItem');
+    if (templateItem) {
+        _cachedLegacyTemplateItem = templateItem.cloneNode(true);
+    }
+
+    if (!_cachedLegacyTemplateItem) return;
+
+    for (const [index, reply] of _cachedSavedReplies.entries()) {
+        const item = createLegacyReplyListItem(_cachedLegacyTemplateItem, reply, index);
+        list.appendChild(item);
+    }
+
+    console.log("onLegacyDialogOpened: injected", _cachedSavedReplies.length, "replies");
+};
+
+const tryLegacyInject = () => {
+    const list = document.querySelector('dialog.js-saved-reply-container[open] ul.js-saved-reply-menu');
+    if (list) {
+        injectIntoLegacyList(list);
+        return true;
+    }
+    return false;
+};
+
+const onLegacyDialogDetected = (dialog) => {
+    const actualDialog = dialog.nodeName === 'DIALOG'
+        ? dialog
+        : dialog.querySelector('dialog.js-saved-reply-container')
+            || dialog.querySelector('dialog');
+
+    if (!actualDialog) return;
+
+    // If dialog is already open, inject now
+    if (actualDialog.hasAttribute('open')) {
+        onLegacyDialogReady(actualDialog);
+        return;
+    }
+
+    // Dialog is closed (pre-rendered on page load). Watch for it to open.
+    const openObserver = new MutationObserver(() => {
+        if (actualDialog.hasAttribute('open')) {
+            onLegacyDialogReady(actualDialog);
+        }
+    });
+    openObserver.observe(actualDialog, { attributes: true, attributeFilter: ['open'] });
+};
+
+const onLegacyDialogReady = async (actualDialog) => {
+    if (!_cachedSavedReplies) {
+        _cachedSavedReplies = await getMatchingSavedReplyConfigsFromLocalStorage(null);
+    }
+
+    if (!_cachedSavedReplies || _cachedSavedReplies.length === 0) return;
+
+    if (tryLegacyInject()) return;
+
+    // Content loads lazily via <include-fragment>. Poll until the list appears.
+    let attempts = 0;
+    const interval = setInterval(() => {
+        if (tryLegacyInject() || ++attempts > 25) {
+            clearInterval(interval);
+        }
+    }, 200);
+};
+
+// --- Dialog detection and observer ---
+
+const onSavedRepliesDialogOpened = async (dialog) => {
+    if (isPrimerReactDialog(dialog)) {
+        await onPrimerReactDialogOpened(dialog);
+    } else if (isLegacyDialog(dialog)) {
+        onLegacyDialogDetected(dialog);
+    }
 };
 
 const observeSavedRepliesDialog = () => {
@@ -291,16 +401,27 @@ const observeSavedRepliesDialog = () => {
 
     console.log("observeSavedRepliesDialog: observer active");
 
+    // Scan for legacy dialogs already in the DOM (and retry, as GitHub may add them after page load)
+    scanForLegacyDialogs();
+    setTimeout(scanForLegacyDialogs, 1000);
+    setTimeout(scanForLegacyDialogs, 3000);
+
     const observer = new MutationObserver((mutations) => {
         for (const mutation of mutations) {
             for (const node of mutation.addedNodes) {
                 if (node.nodeType !== Node.ELEMENT_NODE) continue;
 
                 let dialog = null;
+
+                // Primer React: div[role="dialog"]
                 if (node.getAttribute && node.getAttribute('role') === 'dialog') {
                     dialog = node;
+                } else if (node.nodeName === 'DIALOG' || node.nodeName === 'DIALOG-HELPER') {
+                    // Legacy: <dialog> or <dialog-helper>
+                    dialog = node;
                 } else if (node.querySelector) {
-                    dialog = node.querySelector('[role="dialog"]');
+                    dialog = node.querySelector('[role="dialog"]')
+                        || node.querySelector('dialog.js-saved-reply-container');
                 }
 
                 if (dialog && isSavedRepliesDialog(dialog)) {
@@ -313,8 +434,20 @@ const observeSavedRepliesDialog = () => {
     observer.observe(document.body, { childList: true, subtree: true });
 };
 
+const scanForLegacyDialogs = () => {
+    document.querySelectorAll('dialog.js-saved-reply-container').forEach(dialog => {
+        onLegacyDialogDetected(dialog);
+    });
+};
+
 document.addEventListener("soft-nav:end", () => {
     _cachedSavedReplies = null;
     _cachedTemplateItem = null;
     _cachedListboxClone = null;
+    _cachedLegacyTemplateItem = null;
+
+    // Re-scan after navigation since dialog may be added by GitHub's JS
+    scanForLegacyDialogs();
+    setTimeout(scanForLegacyDialogs, 1000);
+    setTimeout(scanForLegacyDialogs, 3000);
 });

--- a/src/ChromeExtension/pages/content-script/content-script.js
+++ b/src/ChromeExtension/pages/content-script/content-script.js
@@ -57,3 +57,5 @@ document.addEventListener("soft-nav:end", main);
 main().catch((error) => {
     console.error("Oh no!", error);
 });
+
+observeSavedRepliesDialog();

--- a/src/ChromeExtension/pages/content-script/content-script.js
+++ b/src/ChromeExtension/pages/content-script/content-script.js
@@ -1,5 +1,13 @@
 
+const isSidebarButtonEnabled = async () => {
+    const result = await chrome.storage.local.get(["settings"]);
+    const settings = result["settings"];
+    return settings?.showSidebarButtonDefault ?? true;
+};
+
 const showHideSavedRepliesButton = async (showButton) => {
+
+    if (!await isSidebarButtonEnabled()) return;
 
     var showSavedRepliesButton =
         document.querySelector(".show-saved-replies-button-container");
@@ -32,6 +40,8 @@ const main = async () => {
     if (!shouldLoadContentScript(url)) {
         return;
     }
+
+    if (!await isSidebarButtonEnabled()) return;
 
     const showSavedRepliesButton =
         document.querySelector(".show-saved-replies-button-container");

--- a/src/ChromeExtension/pages/options/options.html
+++ b/src/ChromeExtension/pages/options/options.html
@@ -40,24 +40,34 @@
                     <input id="limitToGitHubOwner" minlength="3" class="dialogInput" type="text"
                         data-errorMessage="Please enter a GitHub organziation name or user name." disabled />
                 </div>
-                <div>
+                <div class="twoColumn leftColumn">
                     <label class="label">Applies to Issues:</label>
                     <label class="toggle">
                         <input id="includeIssues" class="dialogInput toggle-checkbox" type="checkbox" checked>
                         <div class="toggle-switch"></div>
                     </label>
                 </div>
-                <div>
+                <div class="twoColumn rightColumn">
                     <label class="label">Applies to Pull Requests:</label>
                     <label class="toggle">
                         <input id="includePullRequests" class="dialogInput toggle-checkbox" type="checkbox" checked>
                         <div class="toggle-switch"></div>
                     </label>
                 </div>
-                <div class="twoColumn leftColumn">
+                <div style="clear: both;">
                     <label class="label">Refresh rate in minutes:</label>
                     <input id="refreshRateInMinutes" class="dialogInput" type="number" min="1" max="60" value="1"
                         data-errorMessage="Please enter a number." required />
+                </div>
+                <div style="padding-top: 20px; padding-bottom: 20px;">
+                    <div style="display: flex; align-items: center; gap: 8px;">
+                        <label class="label" style="margin: 0;">Show sidebar button on GitHub:</label>
+                        <span title="Shared saved replies are also available via GitHub's built-in saved replies button above a comment." style="cursor: help; display: inline-flex; align-items: center; justify-content: center; width: 18px; height: 18px; border-radius: 50%; border: 1px solid var(--foreground-primary, #666); font-size: 12px; font-weight: bold; color: var(--foreground-primary, #666);">i</span>
+                    </div>
+                    <label class="toggle">
+                        <input id="showSidebarButton" class="dialogInput toggle-checkbox" type="checkbox" checked>
+                        <div class="toggle-switch"></div>
+                    </label>
                 </div>
             </div>
         </div>

--- a/src/ChromeExtension/pages/options/options.js
+++ b/src/ChromeExtension/pages/options/options.js
@@ -11,6 +11,7 @@ const getFormValues = () => {
         includeIssuesDefault: document.getElementById(`includeIssues`).checked,
         includePullRequestsDefault: document.getElementById(`includePullRequests`).checked,
         refreshRateInMinutesDefault: document.getElementById(`refreshRateInMinutes`).value,
+        showSidebarButtonDefault: document.getElementById(`showSidebarButton`).checked,
     };
 }
 
@@ -64,6 +65,7 @@ const loadForm = async () => {
     document.getElementById(`includeIssues`).checked = settings.includeIssues;
     document.getElementById(`includePullRequests`).checked = settings.includePullRequests;
     document.getElementById(`refreshRateInMinutes`).value = Number(settings.refreshRateInMinutes);
+    document.getElementById(`showSidebarButton`).checked = settings.showSidebarButton ?? true;
 
     const themesElement = document.querySelector(`select`);
 

--- a/src/ChromeExtension/pages/service-worker/service-worker-settings.js
+++ b/src/ChromeExtension/pages/service-worker/service-worker-settings.js
@@ -9,6 +9,7 @@ const getInitalSettings = () => {
         includeIssuesDefault: true,
         includePullRequestsDefault: true,
         refreshRateInMinutesDefault: `5`,
+        showSidebarButtonDefault: true,
     }
 }
 
@@ -16,10 +17,10 @@ const getSettings = async () =>{
     const result = await chrome.storage.local.get([`settings`]);
 
     if(arrayIsNullOrEmpty(result) || isNullOrEmpty(result[`settings`])){
-        return result[`settings`];
+        return null;
     }
 
-    return null;
+    return result[`settings`];
 }
 
 const saveInitialSettings = async () => {

--- a/src/FirefoxExtension/js/modules/settings.js
+++ b/src/FirefoxExtension/js/modules/settings.js
@@ -17,7 +17,8 @@ const getSettings = async () => {
         limitToGitHubOwner: settings.limitToGitHubOwnerDefault,
         includeIssues: settings.includeIssuesDefault,
         includePullRequests: settings.includePullRequestsDefault,
-        refreshRateInMinutes: settings.refreshRateInMinutesDefault
+        refreshRateInMinutes: settings.refreshRateInMinutesDefault,
+        showSidebarButton: settings.showSidebarButtonDefault ?? true
     }
 }
 

--- a/src/FirefoxExtension/js/urls.js
+++ b/src/FirefoxExtension/js/urls.js
@@ -25,7 +25,7 @@ const isGitHubIssueUrl = (url) => {
         url = window.location.href;
      }
  
-     const issueUrlPattern = /^(https?:\/\/)github\.com\/.+\/.+\/issues\/\d+/i;
+     const issueUrlPattern = /^(https?:\/\/)github\.com\/.+\/.+\/issues\/(\d+|new)/i;
  
      const projectIssueUrlPattern = /^https:\/\/github.com\/(orgs|users)\/(?<owner>\w+)\/projects\/\d+(?:.*)(?:[?|&]pane=\S+&*)(?:issue=\S+)/i;
  
@@ -60,7 +60,7 @@ const getGitHubOwner = (url) => {
         url = window.location.href;
     }
 
-    const issueOrPrOwnerPattern = /https:\/\/github.com\/(?<owner>[\w]+)\/\w+\/(pull|issues)\/.+/i
+    const issueOrPrOwnerPattern = /https:\/\/github.com\/(?<owner>[\w.-]+)\/[\w.-]+\/(pull|issues)\/.+/i
 
     if(issueOrPrOwnerPattern.test(url)){
        

--- a/src/FirefoxExtension/manifest.json
+++ b/src/FirefoxExtension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Shared Saved Replies",
   "description": "Adds saved replies to GitHub's saved replies list when commenting on issues or pull requests.",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "action":{
     "default_popup": "pages/popup/popup.html"
   },

--- a/src/FirefoxExtension/pages/content-script/content-script-copy-saved-reply-element.js
+++ b/src/FirefoxExtension/pages/content-script/content-script-copy-saved-reply-element.js
@@ -1,186 +1,295 @@
-const getsSavedRepliesForNestedIssuesContainer = () =>
-     document.querySelector(`#__primerPortalRoot__  div[role="listbox"] > div`);
+const SHARED_REPLY_ATTR = "data-shared-saved-reply";
+const SHARED_LISTBOX_ATTR = "data-shared-saved-reply-listbox";
+let _cachedSavedReplies = null;
+let _cachedTemplateItem = null;
+let _cachedListboxClone = null;
+let _dialogObserverActive = false;
 
-const getLastExistingSavedReplyElement = (savedRepliesContainer) => {
-    
-    let savedReplyElements = 
-        savedRepliesContainer.querySelectorAll(`div[tabindex="-1"][role="option"]`);
+const isSavedRepliesDialog = (element) => {
+    if (!element || !element.querySelector) return false;
+    return element.querySelector('input[placeholder="Search saved replies"]') !== null;
+};
 
-     let lastSavedReplyElement = savedReplyElements[savedReplyElements.length- 1]
+const matchesSearch = (reply, searchText) => {
+    if (!searchText) return true;
+    return reply.name.toLowerCase().includes(searchText);
+};
 
-     return lastSavedReplyElement;
-}
-   
-const calculateSavedReplyId = (lastId, savedReplyIndex) => {
-   
-   let numberIndex = lastId.search(`[0-9]`);
-   
-   if(numberIndex !== -1){
-      
-      let lastIdNumber = Number(lastId.substring(numberIndex)); 
-      
-      let newNumericalId = lastIdNumber + savedReplyIndex + 1;
+const insertReplyIntoTextarea = (body) => {
+    const textarea = document.querySelector(
+        'textarea[name="comment[body]"], div[data-testid="markdown-editor-comment-composer"] textarea, textarea[class*="prc-Textarea-TextArea"]'
+    );
+    if (!textarea) return;
 
-      let idPrefix = lastId.substring(0, numberIndex);
-      
-      let newId = idPrefix + new String(newNumericalId);
-      
-      return newId;
-   }
-   else{
-        
-        return lastId;
-   }
-}
+    textarea.focus();
 
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const currentValue = textarea.value;
+    const newValue = currentValue.substring(0, start) + body + currentValue.substring(end);
 
+    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+        window.HTMLTextAreaElement.prototype, 'value'
+    ).set;
 
-const setElementSavedReplyName = (element, name) =>{
+    nativeInputValueSetter.call(textarea, newValue);
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
 
-    element.setAttribute(`saved-reply-name`, name);
-}
+    const newCursorPos = start + body.length;
+    textarea.setSelectionRange(newCursorPos, newCursorPos);
+};
 
+const closeSavedRepliesDialog = () => {
+    const target = document.activeElement || document.body;
+    target.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Escape',
+        code: 'Escape',
+        keyCode: 27,
+        which: 27,
+        bubbles: true,
+        cancelable: true
+    }));
+};
 
-const setSavedReplyId = (element,calculatedId) => {
- 
-    element.id = calculatedId;
-}
+const ACTIVE_ATTR = "data-shared-active";
 
-const setSavedReplyName = (nameSpan, name) => {
-     
-    nameSpan.innerText = name;
-}
+const createReplyListItem = (templateItem, reply, index) => {
+    const item = templateItem.cloneNode(true);
 
+    item.setAttribute(SHARED_REPLY_ATTR, "true");
 
-const encodeSavedReplyBody = (body) => {
-   
-   let updatedBody = 
-        body.replace(/\r\n/gi, '\\uFFFD')
-            .replace(/\n/gi,'\\uFFFD');
+    const baseId = `shared-reply-${index}`;
+    item.id = baseId;
+    item.setAttribute("data-id", `shared-${index}`);
+    item.removeAttribute("data-first-child");
+    item.removeAttribute("aria-current");
+    item.removeAttribute("data-is-active-descendant");
+    item.setAttribute("aria-selected", "false");
+    item.setAttribute("aria-labelledby", `${baseId}--label`);
+    item.setAttribute("aria-describedby", `${baseId}--block-description`);
 
-   return updatedBody;
-}
-
-const setSavedReplyBody = (bodySpan, body) => {
-
-    let encodedBody = encodeSavedReplyBody(body);
-
-    bodySpan.innerText = encodedBody;
-}
-
-const createNewSavedReplyElementFromExistingElment = (templateElement, savedReply, index) => {
-
-    let spans = templateElement.querySelectorAll(`span`);
-    console.log("bodyspan", spans[1]);
-    console.log("bodyspanInnerText", spans[1].innerText);
-    console.log("savereplybody", savedReply.body);
-
-    let newSavedReplyElement = templateElement.cloneNode(true);
-    
-    let savedReplySpans = newSavedReplyElement.querySelectorAll(`span`);
-
-    let nameSpan = savedReplySpans[0];
-
-    let bodySpan = savedReplySpans[1];
-
-    setElementSavedReplyName(newSavedReplyElement, savedReply.name);
-
-    setSavedReplyName(nameSpan, savedReply.name);
-
-    setSavedReplyBody(bodySpan, savedReply.body);
-
-    let id = calculateSavedReplyId(templateElement.id, index);
-
-    setSavedReplyId(newSavedReplyElement, id);
-
-    return newSavedReplyElement;
-}
-
-const createSavedRepliesUIForNestedIssues = (savedReplies) => {
-
-    let savedRepliesDivs = [];
-
-    let savedRepliesContainer = getsSavedRepliesForNestedIssuesContainer();
-
-    let lastSavedReplyElement = getLastExistingSavedReplyElement(savedRepliesContainer);
-  
-    for (const [index, reply] of savedReplies.entries()){
-
-        let newElement = 
-            createNewSavedReplyElementFromExistingElment(lastSavedReplyElement, reply, index);
-
-        savedRepliesDivs.push(newElement);
+    // Hide the checkmark SVG but keep the selection span for indentation and blue bar
+    const checkmark = item.querySelector('[data-component="ActionList.Selection"] svg');
+    if (checkmark) {
+        checkmark.style.visibility = "hidden";
     }
 
-    return savedRepliesDivs;
-}
 
-const addNewSavedReplyElementToContainer = (savedRepliesContainer,savedReplyElement ) => {
-    
-    savedRepliesContainer.appendChild(savedReplyElement);
-}
+    const labelSpan = item.querySelector('[id$="--label"]');
+    if (labelSpan) {
+        labelSpan.id = `${baseId}--label`;
+        labelSpan.textContent = reply.name;
+    }
 
-const getElementSavedReplyName = (element) =>{
+    const descSpan = item.querySelector('[data-component="ActionList.Description"]');
+    if (descSpan) {
+        descSpan.id = `${baseId}--block-description`;
+        descSpan.textContent = reply.body;
+    }
 
-    return element.getAttribute(`saved-reply-name`);
-}
+    const trailingVisual = item.querySelector('[id$="--trailing-visual"]');
+    if (trailingVisual) {
+        trailingVisual.id = `${baseId}--trailing-visual`;
+        trailingVisual.textContent = "";
+    }
 
-const getSavedReplyTitleSpan = (savedReplyDiv) => {
-
-}
-
-const getSavedReplyTemplateString = (savedReplyDiv) =>{
-    
-    let bodySpan = savedReplyDiv.querySelectorAll(`span`)[1]
-    
-    let decodedTemplate = bodySpan.innerText
-        .replace(/(\\uFFFD)+/gi,'<br />');
-
-    return decodedTemplate;
-}
-
-const addEventListenerToSavedReplyDiv = (savedReplyDiv, textAreaElement) =>{
-    
-    let templateString = getSavedReplyTemplateString(savedReplyDiv, textAreaElement);
-       
-    savedReplyDiv.addEventListener(`click`, function(e){
-
-        textAreaElement.innerHtml = templateString;
-
-        console.log("text area value", textAreaElement.value);
-
+    item.addEventListener("mouseenter", () => {
+        const listbox = item.closest('ul[role="listbox"]');
+        listbox?.querySelectorAll("[data-is-active-descendant]").forEach(el => {
+            el.removeAttribute("data-is-active-descendant");
+            el.removeAttribute(ACTIVE_ATTR);
+            el.style.backgroundColor = "";
+        });
+        item.setAttribute("data-is-active-descendant", "true");
+        item.setAttribute(ACTIVE_ATTR, "true");
+        if (listbox) listbox.setAttribute("data-has-active-descendant", item.id);
+    });
+    item.addEventListener("mouseleave", () => {
+        item.removeAttribute("data-is-active-descendant");
+        item.removeAttribute(ACTIVE_ATTR);
+        const listbox = item.closest('ul[role="listbox"]');
+        if (listbox) listbox.removeAttribute("data-has-active-descendant");
     });
 
-}
+    item.addEventListener("click", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        insertReplyIntoTextarea(reply.body);
+        closeSavedRepliesDialog();
+    });
 
-const getCommentTextAreaElement = () => {
+    return item;
+};
 
-    let textAreaElement =
-    document.querySelector(
-        `div[data-testid="markdown-editor-comment-composer"] textarea`);
+const injectSharedReplies = (listbox, savedReplies, searchText) => {
+    listbox.querySelectorAll(`[${SHARED_REPLY_ATTR}]`).forEach(el => el.remove());
 
-    return textAreaElement;
-}
+    const nativeItem = listbox.querySelector(`li[role="option"]:not([${SHARED_REPLY_ATTR}])`);
+    if (nativeItem) {
+        _cachedTemplateItem = nativeItem.cloneNode(true);
+    }
 
-const addNewSavedRepliesToNestedIssuesContainer = (savedRepliesDivs, savedRepliesContainer) =>{
-   
-    let textAreaElement = getCommentTextAreaElement();
+    if (!_cachedTemplateItem) return;
 
-    for (const savedReplyDiv of savedRepliesDivs){
+    const filteredReplies = savedReplies.filter(r => matchesSearch(r, searchText));
 
-        let savedReplyName = savedReplyDiv.getAttribute(`saved-reply-name`);
+    for (const [index, reply] of filteredReplies.entries()) {
+        const item = createReplyListItem(_cachedTemplateItem, reply, index);
+        listbox.appendChild(item);
+    }
+};
 
-        let matchingDiv = savedRepliesContainer.querySelector(`div[saved-reply-name="${savedReplyName}"]`);
+const getOrCreateListbox = (dialog) => {
+    const previouslyCreated = dialog.querySelector(`[${SHARED_LISTBOX_ATTR}]`);
 
-        if(!matchingDiv){
-
-            addEventListenerToSavedReplyDiv(savedReplyDiv, textAreaElement);
-
-            savedRepliesContainer.appendChild(savedReplyDiv);
+    const existingListbox = dialog.querySelector(`ul[role="listbox"]:not([${SHARED_LISTBOX_ATTR}])`);
+    if (existingListbox) {
+        if (previouslyCreated) {
+            previouslyCreated.remove();
         }
-     }
-}
+        return existingListbox;
+    }
 
-const removeNewSavedRepliesToNestedIssuesContainer = () =>{
-    
-}
+    if (!_cachedListboxClone) return null;
+
+    const container = dialog.querySelector('[data-testid="filtered-action-list"] > div:last-child')
+        || dialog.querySelector('[data-testid="filtered-action-list"]');
+    if (!container) return null;
+
+    if (previouslyCreated) {
+        return previouslyCreated;
+    }
+
+    const listbox = _cachedListboxClone.cloneNode(false);
+    listbox.setAttribute(SHARED_LISTBOX_ATTR, "true");
+    container.prepend(listbox);
+
+    return listbox;
+};
+
+const hideNoItemsMessage = (dialog, hide) => {
+    const message = dialog.querySelector('[class*="SelectPanel-Message"]');
+    if (message) {
+        message.style.display = hide ? "none" : "";
+    }
+};
+
+const injectIntoCurrentListbox = (dialog, searchText) => {
+    const listbox = getOrCreateListbox(dialog);
+    if (!listbox) return;
+
+    injectSharedReplies(listbox, _cachedSavedReplies, searchText);
+
+    const hasSharedItems = listbox.querySelector(`[${SHARED_REPLY_ATTR}]`) !== null;
+    hideNoItemsMessage(dialog, hasSharedItems);
+};
+
+const onSavedRepliesDialogOpened = async (dialog) => {
+    if (!_cachedSavedReplies) {
+        _cachedSavedReplies = await getMatchingSavedReplyConfigsFromLocalStorage(null);
+    }
+
+    if (!_cachedSavedReplies || _cachedSavedReplies.length === 0) return;
+
+    const initialInject = () => {
+        const listbox = dialog.querySelector('ul[role="listbox"]');
+        if (!listbox) return false;
+
+        _cachedListboxClone = listbox.cloneNode(false);
+        _cachedListboxClone.removeAttribute("data-has-active-descendant");
+
+        injectSharedReplies(listbox, _cachedSavedReplies, "");
+
+        dialog.addEventListener("input", (e) => {
+            if (!e.target.matches('input[placeholder="Search saved replies"]')) return;
+            const searchText = e.target.value.toLowerCase();
+            setTimeout(() => injectIntoCurrentListbox(dialog, searchText), 0);
+        });
+
+        dialog.addEventListener("keydown", (e) => {
+            if (e.key !== "ArrowDown" && e.key !== "ArrowUp" && e.key !== "Enter") return;
+
+            const currentListbox = getOrCreateListbox(dialog);
+            if (!currentListbox) return;
+
+            const hasNativeItems = currentListbox.querySelector(`li[role="option"]:not([${SHARED_REPLY_ATTR}])`);
+            if (hasNativeItems) return;
+
+            const items = Array.from(currentListbox.querySelectorAll(`[${SHARED_REPLY_ATTR}]`));
+            if (items.length === 0) return;
+
+            e.preventDefault();
+            e.stopPropagation();
+
+            const selectedIndex = items.findIndex(item => item.hasAttribute(ACTIVE_ATTR));
+
+            if (e.key === "Enter") {
+                if (selectedIndex >= 0) {
+                    items[selectedIndex].click();
+                }
+                return;
+            }
+
+            let nextIndex;
+            if (e.key === "ArrowDown") {
+                nextIndex = selectedIndex < items.length - 1 ? selectedIndex + 1 : 0;
+            } else {
+                nextIndex = selectedIndex > 0 ? selectedIndex - 1 : items.length - 1;
+            }
+
+            items.forEach(item => {
+                item.removeAttribute(ACTIVE_ATTR);
+                item.removeAttribute("data-is-active-descendant");
+                item.style.backgroundColor = "";
+            });
+            items[nextIndex].setAttribute(ACTIVE_ATTR, "true");
+            items[nextIndex].setAttribute("data-is-active-descendant", "true");
+            items[nextIndex].style.backgroundColor = "var(--control-transparent-bgColor-hover, rgba(175,184,193,0.12))";
+            currentListbox.setAttribute("data-has-active-descendant", items[nextIndex].id);
+            items[nextIndex].scrollIntoView({ block: "nearest" });
+        });
+
+        return true;
+    };
+
+    if (initialInject()) return;
+
+    const dialogObserver = new MutationObserver(() => {
+        if (initialInject()) {
+            dialogObserver.disconnect();
+        }
+    });
+    dialogObserver.observe(dialog, { childList: true, subtree: true });
+};
+
+const observeSavedRepliesDialog = () => {
+    if (_dialogObserverActive) return;
+    _dialogObserverActive = true;
+
+    const observer = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+            for (const node of mutation.addedNodes) {
+                if (node.nodeType !== Node.ELEMENT_NODE) continue;
+
+                let dialog = null;
+                if (node.getAttribute && node.getAttribute('role') === 'dialog') {
+                    dialog = node;
+                } else if (node.querySelector) {
+                    dialog = node.querySelector('[role="dialog"]');
+                }
+
+                if (dialog && isSavedRepliesDialog(dialog)) {
+                    onSavedRepliesDialogOpened(dialog);
+                }
+            }
+        }
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
+};
+
+document.addEventListener("soft-nav:end", () => {
+    _cachedSavedReplies = null;
+    _cachedTemplateItem = null;
+    _cachedListboxClone = null;
+});

--- a/src/FirefoxExtension/pages/content-script/content-script-copy-saved-reply-element.js
+++ b/src/FirefoxExtension/pages/content-script/content-script-copy-saved-reply-element.js
@@ -1,14 +1,31 @@
 const SHARED_REPLY_ATTR = "data-shared-saved-reply";
 const SHARED_LISTBOX_ATTR = "data-shared-saved-reply-listbox";
+const ACTIVE_ATTR = "data-shared-active";
 let _cachedSavedReplies = null;
 let _cachedTemplateItem = null;
 let _cachedListboxClone = null;
+let _cachedLegacyTemplateItem = null;
 let _dialogObserverActive = false;
 
-const isSavedRepliesDialog = (element) => {
+// --- Detection ---
+
+const isPrimerReactDialog = (element) => {
     if (!element || !element.querySelector) return false;
     return element.querySelector('input[placeholder="Search saved replies"]') !== null;
 };
+
+const isLegacyDialog = (element) => {
+    if (!element) return false;
+    if (element.classList?.contains('js-saved-reply-container')) return true;
+    if (element.querySelector?.('.js-saved-reply-container')) return true;
+    return false;
+};
+
+const isSavedRepliesDialog = (element) => {
+    return isPrimerReactDialog(element) || isLegacyDialog(element);
+};
+
+// --- Shared helpers ---
 
 const matchesSearch = (reply, searchText) => {
     if (!searchText) return true;
@@ -17,7 +34,7 @@ const matchesSearch = (reply, searchText) => {
 
 const insertReplyIntoTextarea = (body) => {
     const textarea = document.querySelector(
-        'textarea[name="comment[body]"], div[data-testid="markdown-editor-comment-composer"] textarea, textarea[class*="prc-Textarea-TextArea"]'
+        '#new_comment_field, textarea[name="comment[body]"], div[data-testid="markdown-editor-comment-composer"] textarea, textarea[class*="prc-Textarea-TextArea"]'
     );
     if (!textarea) return;
 
@@ -51,7 +68,7 @@ const closeSavedRepliesDialog = () => {
     }));
 };
 
-const ACTIVE_ATTR = "data-shared-active";
+// --- Primer React dialog (issues, new issues) ---
 
 const createReplyListItem = (templateItem, reply, index) => {
     const item = templateItem.cloneNode(true);
@@ -68,12 +85,10 @@ const createReplyListItem = (templateItem, reply, index) => {
     item.setAttribute("aria-labelledby", `${baseId}--label`);
     item.setAttribute("aria-describedby", `${baseId}--block-description`);
 
-    // Hide the checkmark SVG but keep the selection span for indentation and blue bar
     const checkmark = item.querySelector('[data-component="ActionList.Selection"] svg');
     if (checkmark) {
         checkmark.style.visibility = "hidden";
     }
-
 
     const labelSpan = item.querySelector('[id$="--label"]');
     if (labelSpan) {
@@ -184,7 +199,9 @@ const injectIntoCurrentListbox = (dialog, searchText) => {
     hideNoItemsMessage(dialog, hasSharedItems);
 };
 
-const onSavedRepliesDialogOpened = async (dialog) => {
+const onPrimerReactDialogOpened = async (dialog) => {
+    console.log("onPrimerReactDialogOpened: dialog detected");
+
     if (!_cachedSavedReplies) {
         _cachedSavedReplies = await getMatchingSavedReplyConfigsFromLocalStorage(null);
     }
@@ -262,9 +279,132 @@ const onSavedRepliesDialogOpened = async (dialog) => {
     dialogObserver.observe(dialog, { childList: true, subtree: true });
 };
 
+// --- Legacy dialog (PRs) ---
+
+const createLegacyReplyListItem = (templateItem, reply, index) => {
+    const item = templateItem.cloneNode(true);
+
+    item.setAttribute(SHARED_REPLY_ATTR, "true");
+    item.setAttribute("data-value", reply.name);
+
+    const labelSpan = item.querySelector('.ActionListItem-label');
+    if (labelSpan) {
+        labelSpan.textContent = reply.name;
+    }
+
+    const bodySpan = item.querySelector('.js-saved-reply-body .Truncate-text');
+    if (bodySpan) {
+        bodySpan.textContent = reply.body;
+    }
+
+    const trailingLabel = item.querySelector('.ActionListItem-visual--trailing .Label');
+    if (trailingLabel) {
+        trailingLabel.textContent = "";
+    }
+
+    const button = item.querySelector('button');
+    if (button) {
+        button.addEventListener("click", (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            insertReplyIntoTextarea(reply.body);
+
+            const dialogEl = item.closest('dialog');
+            if (dialogEl) dialogEl.close();
+        });
+    }
+
+    return item;
+};
+
+const injectIntoLegacyList = (list) => {
+    if (list.querySelector(`[${SHARED_REPLY_ATTR}]`)) return;
+
+    const templateItem = list.querySelector('li.ActionListItem');
+    if (templateItem) {
+        _cachedLegacyTemplateItem = templateItem.cloneNode(true);
+    }
+
+    if (!_cachedLegacyTemplateItem) return;
+
+    for (const [index, reply] of _cachedSavedReplies.entries()) {
+        const item = createLegacyReplyListItem(_cachedLegacyTemplateItem, reply, index);
+        list.appendChild(item);
+    }
+
+    console.log("onLegacyDialogOpened: injected", _cachedSavedReplies.length, "replies");
+};
+
+const tryLegacyInject = () => {
+    const list = document.querySelector('dialog.js-saved-reply-container[open] ul.js-saved-reply-menu');
+    if (list) {
+        injectIntoLegacyList(list);
+        return true;
+    }
+    return false;
+};
+
+const onLegacyDialogDetected = (dialog) => {
+    const actualDialog = dialog.nodeName === 'DIALOG'
+        ? dialog
+        : dialog.querySelector('dialog.js-saved-reply-container')
+            || dialog.querySelector('dialog');
+
+    if (!actualDialog) return;
+
+    // If dialog is already open, inject now
+    if (actualDialog.hasAttribute('open')) {
+        onLegacyDialogReady(actualDialog);
+        return;
+    }
+
+    // Dialog is closed (pre-rendered on page load). Watch for it to open.
+    const openObserver = new MutationObserver(() => {
+        if (actualDialog.hasAttribute('open')) {
+            onLegacyDialogReady(actualDialog);
+        }
+    });
+    openObserver.observe(actualDialog, { attributes: true, attributeFilter: ['open'] });
+};
+
+const onLegacyDialogReady = async (actualDialog) => {
+    if (!_cachedSavedReplies) {
+        _cachedSavedReplies = await getMatchingSavedReplyConfigsFromLocalStorage(null);
+    }
+
+    if (!_cachedSavedReplies || _cachedSavedReplies.length === 0) return;
+
+    if (tryLegacyInject()) return;
+
+    // Content loads lazily via <include-fragment>. Poll until the list appears.
+    let attempts = 0;
+    const interval = setInterval(() => {
+        if (tryLegacyInject() || ++attempts > 25) {
+            clearInterval(interval);
+        }
+    }, 200);
+};
+
+// --- Dialog detection and observer ---
+
+const onSavedRepliesDialogOpened = async (dialog) => {
+    if (isPrimerReactDialog(dialog)) {
+        await onPrimerReactDialogOpened(dialog);
+    } else if (isLegacyDialog(dialog)) {
+        onLegacyDialogDetected(dialog);
+    }
+};
+
 const observeSavedRepliesDialog = () => {
     if (_dialogObserverActive) return;
     _dialogObserverActive = true;
+
+    console.log("observeSavedRepliesDialog: observer active");
+
+    // Scan for legacy dialogs already in the DOM (and retry, as GitHub may add them after page load)
+    scanForLegacyDialogs();
+    setTimeout(scanForLegacyDialogs, 1000);
+    setTimeout(scanForLegacyDialogs, 3000);
 
     const observer = new MutationObserver((mutations) => {
         for (const mutation of mutations) {
@@ -272,10 +412,16 @@ const observeSavedRepliesDialog = () => {
                 if (node.nodeType !== Node.ELEMENT_NODE) continue;
 
                 let dialog = null;
+
+                // Primer React: div[role="dialog"]
                 if (node.getAttribute && node.getAttribute('role') === 'dialog') {
                     dialog = node;
+                } else if (node.nodeName === 'DIALOG' || node.nodeName === 'DIALOG-HELPER') {
+                    // Legacy: <dialog> or <dialog-helper>
+                    dialog = node;
                 } else if (node.querySelector) {
-                    dialog = node.querySelector('[role="dialog"]');
+                    dialog = node.querySelector('[role="dialog"]')
+                        || node.querySelector('dialog.js-saved-reply-container');
                 }
 
                 if (dialog && isSavedRepliesDialog(dialog)) {
@@ -288,8 +434,20 @@ const observeSavedRepliesDialog = () => {
     observer.observe(document.body, { childList: true, subtree: true });
 };
 
+const scanForLegacyDialogs = () => {
+    document.querySelectorAll('dialog.js-saved-reply-container').forEach(dialog => {
+        onLegacyDialogDetected(dialog);
+    });
+};
+
 document.addEventListener("soft-nav:end", () => {
     _cachedSavedReplies = null;
     _cachedTemplateItem = null;
     _cachedListboxClone = null;
+    _cachedLegacyTemplateItem = null;
+
+    // Re-scan after navigation since dialog may be added by GitHub's JS
+    scanForLegacyDialogs();
+    setTimeout(scanForLegacyDialogs, 1000);
+    setTimeout(scanForLegacyDialogs, 3000);
 });

--- a/src/FirefoxExtension/pages/content-script/content-script.js
+++ b/src/FirefoxExtension/pages/content-script/content-script.js
@@ -14,3 +14,5 @@ document.addEventListener("soft-nav:end", main);
 main().catch((error) => {
     console.error("Oh no!", error);
 });
+
+observeSavedRepliesDialog();

--- a/src/FirefoxExtension/pages/options/options.html
+++ b/src/FirefoxExtension/pages/options/options.html
@@ -40,24 +40,34 @@
                     <input id="limitToGitHubOwner" minlength="3" class="dialogInput" type="text"
                         data-errorMessage="Please enter a GitHub organziation name or user name." disabled />
                 </div>
-                <div>
+                <div class="twoColumn leftColumn">
                     <label class="label">Applies to Issues:</label>
                     <label class="toggle">
                         <input id="includeIssues" class="dialogInput toggle-checkbox" type="checkbox" checked>
                         <div class="toggle-switch"></div>
                     </label>
                 </div>
-                <div>
+                <div class="twoColumn rightColumn">
                     <label class="label">Applies to Pull Requests:</label>
                     <label class="toggle">
                         <input id="includePullRequests" class="dialogInput toggle-checkbox" type="checkbox" checked>
                         <div class="toggle-switch"></div>
                     </label>
                 </div>
-                <div class="twoColumn leftColumn">
+                <div style="clear: both;">
                     <label class="label">Refresh rate in minutes:</label>
                     <input id="refreshRateInMinutes" class="dialogInput" type="number" min="1" max="60" value="1"
                         data-errorMessage="Please enter a number." required />
+                </div>
+                <div style="padding-top: 20px; padding-bottom: 20px;">
+                    <div style="display: flex; align-items: center; gap: 8px;">
+                        <label class="label" style="margin: 0;">Show sidebar button on GitHub:</label>
+                        <span title="Shared saved replies are also available via GitHub's built-in saved replies button above a comment." style="cursor: help; display: inline-flex; align-items: center; justify-content: center; width: 18px; height: 18px; border-radius: 50%; border: 1px solid var(--foreground-primary, #666); font-size: 12px; font-weight: bold; color: var(--foreground-primary, #666);">i</span>
+                    </div>
+                    <label class="toggle">
+                        <input id="showSidebarButton" class="dialogInput toggle-checkbox" type="checkbox" checked>
+                        <div class="toggle-switch"></div>
+                    </label>
                 </div>
             </div>
         </div>

--- a/src/FirefoxExtension/pages/options/options.js
+++ b/src/FirefoxExtension/pages/options/options.js
@@ -10,6 +10,7 @@ const getFormValues = () => {
         includeIssuesDefault: document.getElementById(`includeIssues`).checked,
         includePullRequestsDefault: document.getElementById(`includePullRequests`).checked,
         refreshRateInMinutesDefault: document.getElementById(`refreshRateInMinutes`).value,
+        showSidebarButtonDefault: document.getElementById(`showSidebarButton`).checked,
     };
 }
 
@@ -63,6 +64,7 @@ const loadForm = async () => {
     document.getElementById(`includeIssues`).checked = settings.includeIssues;
     document.getElementById(`includePullRequests`).checked = settings.includePullRequests;
     document.getElementById(`refreshRateInMinutes`).value = Number(settings.refreshRateInMinutes);
+    document.getElementById(`showSidebarButton`).checked = settings.showSidebarButton ?? true;
 
     const themesElement = document.querySelector(`select`);
 

--- a/src/FirefoxExtension/pages/service-worker/service-worker-settings.js
+++ b/src/FirefoxExtension/pages/service-worker/service-worker-settings.js
@@ -11,6 +11,7 @@ const getInitalSettings = () => {
         includeIssuesDefault: true,
         includePullRequestsDefault: true,
         refreshRateInMinutesDefault: `30`,
+        showSidebarButtonDefault: true,
     }
 }
 
@@ -21,10 +22,10 @@ const getSettings = async () =>{
     const result = await chrome.storage.local.get([`settings`]);
 
     if(arrayIsNullOrEmpty(result) || isNullOrEmpty(result[`settings`])){
-        return result[`settings`];
+        return null;
     }
 
-    return null;
+    return result[`settings`];
 }
 
 const saveInitialSettings = async () => {


### PR DESCRIPTION
## Summary

This enables the Chrome & Firefox extension to inject template replies into the 'Saved Replies' button for issues and PRs.

## Details

  - Inject shared saved replies directly into GitHub's native saved replies dialog on issue and PR pages, so they appear alongside personal saved replies with full search, keyboard navigation, and click-to-insert support
  - Support both Primer React dialogs (issues, new issues) and legacy HTML dialogs (PRs) which use different DOM structures and lazy-loaded content
  - Fix URL pattern matching for new issue pages (`/issues/new`) and repos with dots or hyphens in their name (e.g. `docs.particular.net`)
  - Add "Show sidebar button on GitHub" option to hide the floating sidebar button, with an info tooltip explaining the native alternative
  - Fix inverted settings check that silently reset all user settings to defaults on every extension reload
  - Bump version to 0.1.0